### PR TITLE
Update Composer version

### DIFF
--- a/docker/docker-setup/README.md
+++ b/docker/docker-setup/README.md
@@ -174,7 +174,7 @@ ADD add-reverse-proxy-host.sh docker/php/
 ADD fpm.conf /usr/local/etc/php-fpm.d/zz.fpm.conf
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-COPY --from=composer /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 ENV PATH $PATH:./vendor/bin
 ```


### PR DESCRIPTION
Add version constraint to Composer to prevent backward compatibility issues.

Ik heb hier alvast voor versie 2 gekozen zodat het future prove is. Nieuwe projecten zouden compatible moeten zijn met die versie. En zo niet dan is het geen probleem om het om te zetten naar versie 1.